### PR TITLE
Fixed TCP-Client re-connection after socket disconnects 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-NLog.Targets.Fluentd Fork: fix TCP Client reconnection to fluentd
-====================
-
 NLog.Targets.Fluentd
 ====================
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+NLog.Targets.Fluentd Fork: fix TCP Client reconnection to fluentd
+====================
+
 NLog.Targets.Fluentd
 ====================
 

--- a/src/NLog.Targets.Fluentd/Fluentd.cs
+++ b/src/NLog.Targets.Fluentd/Fluentd.cs
@@ -24,6 +24,7 @@ using System.Reflection;
 using NLog;
 using MsgPack;
 using MsgPack.Serialization;
+using NLog.Common;
 
 namespace NLog.Targets
 {
@@ -193,6 +194,10 @@ namespace NLog.Targets
         protected override void InitializeTarget()
         {
             base.InitializeTarget();
+        }
+
+        private void InitializeClient()
+        {
             client.NoDelay = this.NoDelay;
             client.ReceiveBufferSize = this.ReceiveBufferSize;
             client.SendBufferSize = this.SendBufferSize;
@@ -207,6 +212,10 @@ namespace NLog.Targets
             {
                 if (!client.Connected)
                 {
+                    Cleanup();
+                    client = new TcpClient();
+                    InitializeClient();
+
                     client.Connect(this.Host, this.Port);
                     this.stream = this.client.GetStream();
                     this.emitter = new FluentdEmitter(this.stream);

--- a/src/NLog.Targets.Fluentd/Fluentd.cs
+++ b/src/NLog.Targets.Fluentd/Fluentd.cs
@@ -198,6 +198,7 @@ namespace NLog.Targets
 
         private void InitializeClient()
         {
+            client = new TcpClient();
             client.NoDelay = this.NoDelay;
             client.ReceiveBufferSize = this.ReceiveBufferSize;
             client.SendBufferSize = this.SendBufferSize;
@@ -210,20 +211,28 @@ namespace NLog.Targets
         {
             try
             {
-                if (!client.Connected)
+                if(client == null)
+                {
+                    InitializeClient();
+                    ConnectClient();
+                }
+                else if (!client.Connected)
                 {
                     Cleanup();
-                    client = new TcpClient();
                     InitializeClient();
-
-                    client.Connect(this.Host, this.Port);
-                    this.stream = this.client.GetStream();
-                    this.emitter = new FluentdEmitter(this.stream);
+                    ConnectClient();
                 }
             }
             catch (Exception e)
             {
             }
+        }
+
+        private void ConnectClient()
+        {
+            client.Connect(this.Host, this.Port);
+            this.stream = this.client.GetStream();
+            this.emitter = new FluentdEmitter(this.stream);
         }
 
         protected void Cleanup()
@@ -304,7 +313,6 @@ namespace NLog.Targets
             LingerTime = 1000;
             EmitStackTraceWhenAvailable = false;
             Tag = Assembly.GetCallingAssembly().GetName().Name;
-            client = new TcpClient();
         }
     }
 }


### PR DESCRIPTION
If the TCP client disconnected the EnsureConnected client.Connected will be false but it want be able to connect because the socket wasn't cleaned.
I changed it so I cleanup the connection and reinitialized the TCPClient object from the start.